### PR TITLE
chore: Bump `nixpkgs` import to 24.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -440,16 +440,16 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1642798845,
-        "narHash": "sha256-1g1X3wKmroGix68OXwb4gR1yXKPQ36apI1dssd/YbuM=",
+        "lastModified": 1725407940,
+        "narHash": "sha256-tiN5Rlg/jiY0tyky+soJZoRzLKbPyIdlQ77xVgREDNM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e84444b14cc75a4be17b58fd2c344f47dddf084e",
+        "rev": "6f6c45b5134a8ee2e465164811e451dcb5ad86e3",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-21.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-21.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
     matthewcroughan.url = "github:matthewcroughan/nixcfg";
   };
 
@@ -16,6 +16,7 @@
           "${matthewcroughan}/mixins/common.nix"
           {
            environment.systemPackages = with nixpkgs.legacyPackages.aarch64-linux.pkgs; [ vim git ];
+          system.stateVersion = "24.05";
            nix = {
              package = nixpkgs.legacyPackages.aarch64-linux.nixUnstable;
              extraOptions = ''


### PR DESCRIPTION
The input for `nixpkgs` was very outdated, so this commit bumps it to
24.05.

It also sets `system.stateVersion`.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>
