### PR TITLE
fix: Use `nixLatest` for Nix package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
           {
            environment.systemPackages = with nixpkgs.legacyPackages.aarch64-linux.pkgs; [ vim git ];
            nix = {
-             package = nixpkgs.legacyPackages.aarch64-linux.nixUnstable;
+             package = nixpkgs.legacyPackages.aarch64-linux.nixVersions.latest;
              extraOptions = ''
                experimental-features = nix-command flakes
              '';


### PR DESCRIPTION
This commit pins `nixLatest` as the package for the Nix package manager.

The previous implementation is no longer supported.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>
