### PR TITLE
fix: Fix `services.ttyd` options

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
             services.tailscale.enable = true;
             services.ttyd.enable = true;
             services.ttyd.openFirewall = true;
+            services.ttyd.writeable = true;
             services.openssh.enable = true;
             hardware.enableRedistributableFirmware = true;
             networking = {


### PR DESCRIPTION
Essentially:

- `services.ttyd.openFirewall` is no longer a option.
- `services.ttyd.writeable` is necessary to set.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>
